### PR TITLE
An example of how to add custom task via roles for vendor specific customization

### DIFF
--- a/playbook_install_client_redhat.yml
+++ b/playbook_install_client_redhat.yml
@@ -22,6 +22,7 @@
     - role: 'generic/os_compatibility'
     - role: 'generic/server_check'       # Make sure that the execution isn't running on a NetBackup Server
     - role: 'generic/nbu_version_check'
+    - role: 'custom/pre-upgrade-backup'
     - role: 'netbackup/redhat/nbu-client-install/v1.0'
     - role: 'netbackup/redhat/nbu-install-eeb/v1.0'
     - role: 'netbackup/redhat/client-get-certificate/v1.0'

--- a/roles/custom/pre-upgrade-backup/tasks/main.yml
+++ b/roles/custom/pre-upgrade-backup/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+# Take backup of critical files before upgrading NetBackup Software
+- name: "Check the existence of bp.conf"
+  ansible.builtin.stat:
+    path: "{{ os_path_nbu_install }}/netbackup/bp.conf"
+  register: bp_conf_stat_register
+  failed_when: false
+  changed_when: false
+
+- name: "create backup directory"
+  ansible.builtin.file:
+    path: /usr/netbackup_saveddata
+    state: directory
+    mode: '0755'
+
+- name: "Save bp.conf to backup location"
+  ansible.builtin.copy:
+    src: "{{ os_path_nbu_install }}/netbackup/bp.conf"
+    dest: /usr/netbackup_saveddata/bp.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when: bp_conf_stat_register.stat.exists


### PR DESCRIPTION
In this example, we have added a custom role (pre-upgrade-backup) having few tasks to take bp.conf backup before upgrading NetBackup software. The role can then be sequenced in respective playbook.