### PR TITLE
A custom role example to showcase how any NB APIs could called.

### DIFF
--- a/playbook_configuration_global_settings.yml
+++ b/playbook_configuration_global_settings.yml
@@ -23,6 +23,7 @@
     - role: 'generic/nbu_compatibility'
     - role: 'netbackup/common/rest-api-integration'
     - role: 'netbackup/common/rest-api-integration/global_settings'
+    - role: 'custom/license_entitlement' # A custom role to apply new entitlement/s
   vars:
     nbu_playbook_type: "global-settings"
     nbu_role: "primary"                  # Supported values ['primary','media','client'] 

--- a/roles/custom/license_entitlement/tasks/main.yml
+++ b/roles/custom/license_entitlement/tasks/main.yml
@@ -1,0 +1,50 @@
+# README
+# 1. The license files need to be uploaded to artifactory location
+# 2. Task 17: Would download files to the ansible controller node
+# 3. Task 26: Run the RESTapi to add the entitlements
+# 4. Task 43: Delete the downlaoded files from ansible control node 
+
+- name: "NBU-LICENSE_ENTITLEMENT -> Create destination path if doesn't exists"
+  ansible.builtin.file:
+    path: "{{ os_path_openv_tmp }}"
+    state: directory
+  delegate_to: localhost
+  run_once: true  
+
+- name: "NBU-LICENSE_ENTITLEMENT -> Download and add entitlements"
+  block:
+    - name: "NBU-LICENSE_ENTITLEMENT -> Download SLIC License files to {{ os_path_openv_tmp  }}"
+      ansible.builtin.get_url:
+        url: "{{ nbu_artifactory_repo_base_url }}{{ artifactory_repo }}{{ nbu_path_support_utilities }}{{ item }}"
+        dest: "{{ os_path_openv_tmp }}/{{ item }}"
+        mode: '744'
+      delegate_to: localhost
+      run_once: true
+      with_items: "{{ nbu_license_file_name_list }}"
+
+    - name: "NBU-LICENSE_ENTITLEMENT -> Adds an entitlement to NetBackup"
+      ansible.builtin.uri:
+        url: "{{ nbu_api_base_url + 'licensing/entitlements' }}"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ user_access_token }}"
+          Content-Type: "multipart/form-data"
+        body_format: form-multipart
+        body:
+          file:
+            content: "{{ lookup('file', '/usr/openv/tmp/{{ item }}') }}"
+            filename: "{{ item }}"
+        status_code: 201, 409
+        validate_certs: no
+      with_items: "{{ nbu_license_file_name_list }}"
+
+  always:
+    - name: "NBU-LICENSE_ENTITLEMENT -> Delete locally stored license files"
+      ansible.builtin.file:
+        path: "{{ os_path_openv_tmp}}/{{ item }}"
+        state: absent
+      delegate_to: localhost
+      run_once: true
+      with_items: "{{ nbu_license_file_name_list }}"
+
+#EOF

--- a/vars/linux.yml
+++ b/vars/linux.yml
@@ -91,7 +91,8 @@ nbu_license_key:
 
 # This option specifies the SLIC file names list valid for nbu_version > "10.2.0.1"
 nbu_license_file_name_list: 
-- "<slice_license1>"
+- "NFR_10.3_2024-07-19.slf"
+- "NFR_10.3_2025-05-16.slf"
 
 # NBCA configuration details
 nbu_primary_certdetails:


### PR DESCRIPTION
Ee are showcasing integration to NetBackup license_entitlement API and how a simple custom role would help applying one or more license files to primary server/s