### PR TITLE
Enable NetBackup 11.1.0.2 and expand Debian and Ubuntu platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The NetBackup Automation Platform provides a robust set of Ansible roles and pla
 This platform offers comprehensive automation capabilities for NetBackup Primary, Media, and Client components:
 
 * **NetBackup Installation & Upgrades**:
-    * Fresh installation and upgrade of NetBackup Client on Windows, SuSE, RHEL, Solaris, AIX, Linux P-series, Linux Z-series, Rocky Linux, and Oracle Linux.
+    * Fresh installation and upgrade of NetBackup Client on Windows, SuSE, RHEL, Solaris, AIX, Linux P-series, Linux Z-series, Rocky Linux, Oracle Linux, Debian and Ubuntu.
     * Fresh installation of NetBackup Media & Primary servers on SuSE and RHEL.
     * Upgrade NetBackup environments (from and to NB version 10.x onwards).
 * **Certificate Management**:
@@ -20,7 +20,7 @@ This platform offers comprehensive automation capabilities for NetBackup Primary
     * Deployment and management of EEBs with automatic marker creation for easy detection.
     * Supports installing multiple EEBs, upgrading EEBs, adjusting subsequent overlapping EEBs, and removing EEBs.
 * **EEB Marker Creation Scripts**:
-    * Automation includes scripts for creating EEB markers, simplifying detection of installed EEBs. Marker creation is supported for all platforms except AIX.
+    * Automation includes scripts for creating EEB markers, simplifying detection of installed EEBs. Marker creation is supported for all platforms except AIX, Debian and Ubuntu.
 * **Package Staging**:
     * Option to cache NetBackup packages locally on target hosts for offline installations.
 * **Global Security Settings**:
@@ -29,11 +29,12 @@ This platform offers comprehensive automation capabilities for NetBackup Primary
     * Playbooks to start, stop, and restart NetBackup services.
 * **DirectIO Support**:
     * On RHEL, DirectIO is supported for Primary, Media, and Client. On Windows, DirectIO is supported for Client only.
-
+    
 
 ## 🎯 Supported NetBackup Versions
 
 These playbooks support the following NetBackup Primary, Media, and Client versions:
+* `11.1.0.2`
 * `11.1.0.0`
 * `11.0.0.1`
 * `11.0.0.0`
@@ -55,7 +56,7 @@ The following table outlines the available playbooks and their functionalities, 
 
 ### NetBackup Client Playbooks
 
-#### Clients (Windows, SuSE, RHEL, Solaris, AIX, Linux P-series, Linux Z-series, Rocky Linux, and Oracle Linux)
+#### Clients (Windows, SuSE, RHEL, Solaris, AIX, Linux P-series, Linux Z-series, Rocky Linux, Oracle Linux, Debian and Ubuntu)
 
 | # | Playbook Name | Description & High-Level Workflow |
 |---|---|---|
@@ -230,14 +231,22 @@ These boolean variables enable or disable specific features.
 Before running the playbooks, ensure the following:
 
 1.  **Ansible Core**: Supports `ansible-core 2.15` onwards.
-2.  **Ansible Automation Platform**: Must be configured and ready for use.
-3.  **Non-interactive Connection**: Establish a non-interactive connection to all managed nodes/target hosts.
-4.  **Artifact Repository Manager**: Configure an artifact repository manager (e.g., a yum repository) and upload all NetBackup RPMs with their respective repodata. This can be a web server accessible via URL, or a local/mounted file-system path.
+2.  **Python Interpreter**: Supports `python version 3.9` onwards.
+3.  **Ansible Automation Platform**: Must be configured and ready for use.
+4.  **Non-interactive Connection**: Establish a non-interactive connection to all managed nodes/target hosts.
+5.  **Artifact Repository Manager**: Configure an artifact repository manager (e.g., a yum repository) and upload all NetBackup RPMs with their respective repodata. This can be a web server accessible via URL, or a local/mounted file-system path.
     * **Client RPMs**: `<NB_Package_DIR>/NetBackup_<NB_VERSION>_CLIENTS2/NBClients/anb/Clients/usr/openv/netbackup/client/Linux/RedHat3.10.0`
+    * **Debian Client Packages**: `We use the complete DVD image for the debian platform and the uploaded image should follow a particular naming convention.`
+            * Image Name: `NetBackup_<NB_VERSION>_CLIENTS2.tar.gz`
+            * Source: `<NB_Package_DIR>/NetBackup_<NB_VERSION>_CLIENTS2. This DVD image contains packages for other platforms. To optimize the space, we could remove:`
+            * `<NB_Package_DIR>/NetBackup_<NB_VERSION>_CLIENTS2/NBClients/anb/Clients/usr/openv/netbackup/client/Linux-ppc64le`
+            * `<NB_Package_DIR>/NetBackup_<NB_VERSION>_CLIENTS2/NBClients/anb/Clients/usr/openv/netbackup/client/Linux-s390x`
+            * `<NB_Package_DIR>/NetBackup_<NB_VERSION>_CLIENTS2/NBClients/anb/Clients/usr/openv/netbackup/client/Linux/RedHat4.18.0`
+            * `<NB_Package_DIR>/NetBackup_<NB_VERSION>_CLIENTS2/NBClients/anb/Clients/usr/openv/netbackup/client/Linux/SuSE5.3.18`
     * **Primary/Media RPMs**: `<NB_Package_DIR>/NetBackup_<NB_VERSION>_LinuxR_x86_64/linuxR_x86/anb`
     * **Client Windows DVD Packages**: `<NB_Package_DIR>/NetBackup_<NB_VERSION>_Win\`
     * **ITA Data Collector (for Primary server)**: `<NB_Package_DIR>/NetBackup_<NB_VERSION>_LinuxR_x86_64/linuxR_x86/catalog/anb/ita_dc.tar.gz`
-5.  **Ansible Inventory**: Ensure the Ansible inventory is pre-populated with your target hosts.
+6.  **Ansible Inventory**: Ensure the Ansible inventory is pre-populated with your target hosts.
 
 
 ### Usage

--- a/playbook_certificate_deployment_linux.yml
+++ b/playbook_certificate_deployment_linux.yml
@@ -12,6 +12,14 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-CERTIFICATE-DEPLOYMENT -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]

--- a/playbook_certificate_deployment_windows.yml
+++ b/playbook_certificate_deployment_windows.yml
@@ -11,6 +11,14 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-CERTIFICATE-DEPLOYMENT -> Load configurable variables"
       ansible.builtin.include_vars: "vars/win32nt.yml"
       tags: ["always"]

--- a/playbook_configuration_global_settings.yml
+++ b/playbook_configuration_global_settings.yml
@@ -12,12 +12,20 @@
           - "!all"
           - "!min"
           - "distribution"
+          
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} Fail if nbu_primary_server_ans is defined"
       ansible.builtin.fail:
         msg: "The 'nbu_primary_server_ans' should not be defined for {{ nbu_role|lower }} {{ nbu_playbook_type|lower }} playbook."
       when:
       - nbu_primary_server_ans is defined
-
+      
     - name: "NBU-GLOBAL-SETTINGS -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]
@@ -33,6 +41,6 @@
     - { role: 'netbackup/common/rest-api-integration',  action: "logout" }
   vars:
     nbu_playbook_type: "global-settings"
-    nbu_role: "primary"                  # Supported values ['primary','media','client']
+    nbu_role: "primary"                  # Supported values ['primary','media','client'] 
 
 # EOF

--- a/playbook_install_client_linux.yml
+++ b/playbook_install_client_linux.yml
@@ -16,6 +16,13 @@
           - "!min"
           - "distribution"
 
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]

--- a/playbook_install_client_windows.yml
+++ b/playbook_install_client_windows.yml
@@ -12,6 +12,13 @@
           - "!min"
           - "distribution"
           - "env"
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/win32nt.yml"
       tags: ["always"]

--- a/playbook_install_media_linux.yml
+++ b/playbook_install_media_linux.yml
@@ -15,6 +15,14 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]

--- a/playbook_install_primary_linux.yml
+++ b/playbook_install_primary_linux.yml
@@ -15,6 +15,13 @@
           - "!all"
           - "!min"
           - "distribution"
+    
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
 
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} Fail if nbu_primary_server_ans is defined"
       ansible.builtin.fail:

--- a/playbook_remove_client_linux.yml
+++ b/playbook_remove_client_linux.yml
@@ -13,6 +13,14 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]

--- a/playbook_remove_client_windows.yml
+++ b/playbook_remove_client_windows.yml
@@ -10,6 +10,14 @@
       setup:
         gather_subset:
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/win32nt.yml"
       tags: ["always"]

--- a/playbook_remove_media_linux.yml
+++ b/playbook_remove_media_linux.yml
@@ -13,6 +13,14 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]

--- a/playbook_remove_primary_linux.yml
+++ b/playbook_remove_primary_linux.yml
@@ -13,6 +13,14 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} Fail if nbu_primary_server_ans is defined"
       ansible.builtin.fail:
         msg: "The 'nbu_primary_server_ans' should not be defined for {{ nbu_role|lower }} {{ nbu_playbook_type|lower }} playbook."

--- a/playbook_restart_services_linux.yml
+++ b/playbook_restart_services_linux.yml
@@ -14,13 +14,20 @@
           - "!min"
           - "distribution"
 
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')      
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]
       no_log: True
 
     - name: "NBU-RESTART-SERVICES -> Input validation for netbackup role"
-      fail:
+      ansible.builtin.fail:
         msg: "'nbu_role' is required to proceed with restart services playbook. Do provide the NetBackup role and re-run the playbook."
       when:
       - nbu_role == ""

--- a/playbook_stage_packages_locally_redhat.yml
+++ b/playbook_stage_packages_locally_redhat.yml
@@ -12,13 +12,21 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+            
     - name: "NBU-STAGE-PACKAGES -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]
       no_log: True
 
     - name: "NBU-STAGE-PACKAGES -> Input validation fo netbackup role"
-      fail:
+      ansible.builtin.fail:
         msg: "'nbu_role' is required to proceed with staging playbook. Do provide the NetBackup role and re-run the playbook."
       when:
       - nbu_role == ""

--- a/playbook_stage_packages_locally_windows.yml
+++ b/playbook_stage_packages_locally_windows.yml
@@ -11,6 +11,14 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-STAGE-PACKAGES -> Load configurable variables"
       ansible.builtin.include_vars: "vars/win32nt.yml"
       tags: ["always"]

--- a/playbook_start_services_linux.yml
+++ b/playbook_start_services_linux.yml
@@ -14,13 +14,20 @@
           - "!min"
           - "distribution"
 
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+      
     - name: "NBU-START-SERVICES -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]
       no_log: True
 
     - name: "NBU-START-SERVICES -> Input validation for netbackup role"
-      fail:
+      ansible.builtin.fail:
         msg: "'nbu_role' is required to proceed with start services playbook. Do provide the NetBackup role and re-run the playbook."
       when:
       - nbu_role == ""

--- a/playbook_stop_services_linux.yml
+++ b/playbook_stop_services_linux.yml
@@ -13,13 +13,21 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+           
     - name: "NBU-STOP-SERVICES -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]
       no_log: True
 
     - name: "NBU-STOP-SERVICES -> Input validation for netbackup role"
-      fail:
+      ansible.builtin.fail:
         msg: "'nbu_role' is required to proceed with stop services playbook. Do provide the NetBackup role and re-run the playbook."
       when:
       - nbu_role == ""

--- a/playbook_upgrade_client_linux.yml
+++ b/playbook_upgrade_client_linux.yml
@@ -15,6 +15,14 @@
           - "!all"
           - "!min"
           - "distribution"
+    
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+      
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]

--- a/playbook_upgrade_client_windows.yml
+++ b/playbook_upgrade_client_windows.yml
@@ -10,6 +10,14 @@
         gather_subset:
           - "distribution"
           - "env"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/win32nt.yml"
       tags: ["always"]

--- a/playbook_upgrade_media_linux.yml
+++ b/playbook_upgrade_media_linux.yml
@@ -15,6 +15,14 @@
           - "!all"
           - "!min"
           - "distribution"
+
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.      
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
+            
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Load configurable variables"
       ansible.builtin.include_vars: "vars/linux.yml"
       tags: ["always"]

--- a/playbook_upgrade_primary_linux.yml
+++ b/playbook_upgrade_primary_linux.yml
@@ -15,6 +15,13 @@
           - "!all"
           - "!min"
           - "distribution"
+    
+    # Python 3.9+ is required for compatibility with Ansible modules and features used in this playbook.
+    # Older Python versions may lack required functionality or security updates.
+    - name: Check Python interpreter version
+      ansible.builtin.fail:
+        msg: "Platform {{ ansible_system|lower }} on host {{ ansible_fqdn }} is using the discovered Python interpreter at {{ ansible_python.executable }}, version {{ ansible_python_version }}, which is below the required minimum of 3.9"
+      when: ansible_python_version is version('3.9', '<')
 
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} Fail if nbu_primary_server_ans is defined"
       ansible.builtin.fail:

--- a/roles/generic/initiate_nbcheck/tasks/posix.yml
+++ b/roles/generic/initiate_nbcheck/tasks/posix.yml
@@ -7,6 +7,7 @@
   with_items:
    - "{{ os_path_openv_tmp  }}/VRTSnbpck{{ package_extension }}"
    - "{{ os_path_openv_tmp  }}/usr"
+   - "{{ os_path_openv_tmp  }}/nbcheck"
 
 - name: "NBCHECK -> Verify base directory {{ os_path_nbu_install_default }} existence"
   stat:
@@ -25,26 +26,26 @@
     path: "{{ os_path_openv_tmp }}"
     state: directory
 
-- name: "NBCHECK -> Download VRTSnbpck package to {{ os_path_openv_tmp  }}"
+- name: "NBCHECK -> Download {{ nbcheck_package_name }} package to {{ os_path_openv_tmp  }}"
   get_url:
-    url: "{{ nbu_artifactory_repo_base_url }}{{ artifactory_repo }}{{ nbu_path_repo_base_pkg }}/VRTSnbpck{{ package_extension }}"
-    dest: "{{ os_path_openv_tmp  }}/VRTSnbpck{{ package_extension }}"
- 
-- name: "NBCHECK -> Check VRTSnbpck package existence in {{ os_path_openv_tmp  }}"
+    url: "{{ nbu_artifactory_repo_base_url }}{{ artifactory_repo }}{{ nbu_path_repo_base_pkg }}/{{ nbcheck_package_name }}{{ package_extension }}"
+    dest: "{{ os_path_openv_tmp  }}/{{nbcheck_package_name}}{{ package_extension }}"
+
+- name: "NBCHECK -> Check {{ nbcheck_package_name }} package existence in {{ os_path_openv_tmp  }}"
   stat:
-    path: "{{ os_path_openv_tmp  }}/VRTSnbpck{{ package_extension }}"
+    path: "{{ os_path_openv_tmp  }}/{{nbcheck_package_name}}{{ package_extension }}"
   no_log: true
   register: file_status_register
 
-- name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Extract VRTSnbpck{{ package_extension }} package"
-  ansible.builtin.shell: ( gunzip -f "VRTSnbpck{{package_extension}}" )
+- name: "NBCHECK -> Extract {{nbcheck_package_name}}{{ package_extension }} package"
+  ansible.builtin.shell: ( gunzip -f "{{nbcheck_package_name}}{{package_extension}}" )
   args:
     chdir: "{{ os_path_openv_tmp }}"
   when:
     - ansible_system == 'AIX' or ansible_system == 'SunOS'
     - file_status_register.stat.exists
 
-- name: "NBCHECK -> Extracting nbcheck file from VRTSnbpck"
+- name: "NBCHECK -> Extracting nbcheck file from {{ nbcheck_package_name }}"
   ansible.builtin.shell: "{{ nbcheck_package_extraction_cmd }}"
   args:
     chdir: "{{ os_path_openv_tmp }}"
@@ -79,7 +80,7 @@
 - name: "NBCHECK -> Passing nbcheck CLI argument when websvc user is different from default web user"
   set_fact:
     nbweb_service_user: "{{ '-Dwebsvc_user='+nbu_webservices_user if nbu_role =='primary' else '' }}"
-    
+
 - name: "NBCHECK -> Passing nbcheck CLI argument when database user is different from default user"
   set_fact:
     postgres_user_param: "{{ '-Dpostgres_user='+nbu_database_user if nbu_role =='primary' else '' }}"

--- a/roles/generic/is_nbu_version_supported/tasks/main.yml
+++ b/roles/generic/is_nbu_version_supported/tasks/main.yml
@@ -7,9 +7,9 @@
   ansible.builtin.set_fact:
     nbu_versions_supported: >-
       {%- if nbap_ansible_system == 'posix' -%}
-        {{ (nbu_pkgs_ordered_list.keys() | list)[0:5] }}
+        {{ (nbu_pkgs_ordered_list.keys() | list)[0:nbu_max_supported_versions] }}
       {%- elif nbap_ansible_system == 'win32nt' -%}
-        {{ (nbu_pkgs_ordered_list['client'].keys() | list)[0:5] }}
+        {{ (nbu_pkgs_ordered_list['client'].keys() | list)[0:nbu_max_supported_versions] }}
       {%- endif -%}
 
 # Verify if the proposed NetBackup software version is supported for install/upgrade

--- a/roles/generic/nbu_compatibility/tasks/role_check.yml
+++ b/roles/generic/nbu_compatibility/tasks/role_check.yml
@@ -3,7 +3,7 @@
 - name: "NBU-ROLE-CHECK -> Fail if target host machine has different role installed other than the playbook role"
   block:
     - name: "NBU-ROLE-CHECK -> Fail if target host machine has different role installed other than the playbook role"
-      fail:
+      ansible.builtin.fail:
         msg: "This machine has NetBackup {{ nbu_detected_role }} installed . Executing this Playbook on {{ nbu_detected_role }} would cause a significant outage."
       when:
         - nbu_role is defined

--- a/roles/netbackup/defaults/main.yml
+++ b/roles/netbackup/defaults/main.yml
@@ -1,30 +1,42 @@
 # $Copyright: Copyright (c) 2025 Cohesity, Inc. All rights reserved $
 
 nbap_ansible_system : "{{ 'win32nt' if 'Win32NT' in ansible_system else 'posix' }}"
+nbu_max_supported_versions: 6
 
 # Ansible - OS family list
 nbu_compatibility_matrix:
+  - appversion: 11.1.0.2
+    os_min_support:
+      RedHat: 8.10
+      Suse: 15
+      AIX: 7.2
+      Solaris: 11.0
+      Windows: 10.0
+      Debian: 12
   - appversion: 11.1.0.0
     os_min_support:
-      RedHat: 8.6
+      RedHat: 8.10
       Suse: 15
-      AIX: 7.1
+      AIX: 7.2
       Solaris: 11.0
-      Windows: 6.2
+      Windows: 10.0
+      Debian: 12
   - appversion: 11.0.0.1
     os_min_support:
-      RedHat: 8.6
+      RedHat: 8.10
       Suse: 15
-      AIX: 7.1
+      AIX: 7.2
       Solaris: 11.0
-      Windows: 6.2
+      Windows: 10.0
+      Debian: 12
   - appversion: 11.0.0.0
     os_min_support:
-      RedHat: 8.6
+      RedHat: 8.10
       Suse: 15
-      AIX: 7.1
+      AIX: 7.2
       Solaris: 11.0
-      Windows: 6.2   
+      Windows: 10.0  
+      Debian: 12 
   - appversion: 10.5.0.1
     os_min_support:
       RedHat: 8.6
@@ -32,6 +44,7 @@ nbu_compatibility_matrix:
       AIX: 7.1
       Solaris: 11.0
       Windows: 6.2
+      Debian: 10
   - appversion: 10.5.0.0
     os_min_support:
       RedHat: 8.6
@@ -39,4 +52,5 @@ nbu_compatibility_matrix:
       AIX: 7.1
       Solaris: 11.0
       Windows: 6.2
+      Debian: 10
       

--- a/roles/netbackup/posix/defaults/main.yml
+++ b/roles/netbackup/posix/defaults/main.yml
@@ -102,6 +102,8 @@ os_dir_nbu_drfiles: "{{ os_path_openv_tmp }}/drfiles"
 
 nbu_db_data_path: "{{ os_path_nbu_install }}/db/data"
 
+netbackup_debian_package: "{{ 'NetBackup_' + (nbu_version | regex_replace('(\\.0)+$', '') | regex_replace('^(\\d+)$', '\\1.0')) + '_CLIENTS2' }}"
+
 # NBU - Config ("Limits")
 nbu_config_nbwebsvc_limit: "nbwebsvc  soft       nproc      8000"
 
@@ -174,6 +176,24 @@ nbcheck_test_name:
 # Ordered list of NetBackup Packages per supported version
 # Important Note: Upgrade is only supported from 10.5.0.0 and above versions for NetBackup client, media and primary.
 nbu_pkgs_ordered_list:
+  11.1.0.2: 
+      - { name: "VRTSnbpck", version: "11.1.0.2" }
+      - { name: "VRTSpbx", version: "1.19.93.0", shared: true }
+      - { name: "VRTSnbclt", version: "11.1.0.2" }
+      - { name: "VRTSnbclibs", version: "11.1.0.2" }
+      - { name: "VRTSnbjre", version: "11.1.0.2", platforms: ["RedHat:x86_64", "RedHat:s390x", "Suse:x86_64", "Suse:s390x", "AIX:chrp"], optional: "{{nb_include_java_jre_install}}" }
+      - { name: "VRTSnbjava", version: "11.1.0.2", platforms: ["RedHat:x86_64", "RedHat:s390x", "Suse:x86_64", "Suse:s390x", "AIX:chrp"], optional: "{{nb_include_java_jre_install}}" }
+      - { name: "VRTSnbdirectio", version: "1.1.0.0", platforms: ["RedHat:x86_64"], optional: "{{nb_include_directio_install}}" }
+      - { name: "VRTSpddes", version: "21.1.0.1", role: ["media", "primary"]}
+      - { name: "VRTSpddeu", version: "21.1.0.1", platforms: ["RedHat:x86_64", "Suse:x86_64"], optional: "{{nb_include_vrtspddeu_client_install}}"}
+      - { name: "VRTSpddea", version: "21.1.0.1", role: ["client"], platforms: ["RedHat:x86_64", "Suse:x86_64", "Solaris:i386", "Solaris:sun4v", "AIX:chrp"] }
+      - { name: "VRTSnbcfg", version: "11.1.0.2" }
+      - { name: "VRTSpostgresql", version: "16.10.1.0", role: ["primary"] } 
+      - { name: "VRTSnetbp", version: "11.1.0.2", role: ["media", "primary"] }
+      - { name: "VRTSnbprimary", version: "11.1.0.2", role: ["primary"] }
+      - { name: "VRTSnbmqbrkr", version: "11.1.0.2", role: ["primary"] }
+      - { name: "VRTSnbweb", version: "11.1.0.2", role: ["primary"] }
+      - { name: "VRTSnbslibs", version: "11.1.0.2", role: ["media", "primary"] }
   11.1.0.0: 
       - { name: "VRTSnbpck", version: "11.1.0.0" }
       - { name: "VRTSpbx", version: "1.19.93.0", shared: true }

--- a/roles/netbackup/posix/nbu-client-install/v2.0/tasks/t02_base_install.yml
+++ b/roles/netbackup/posix/nbu-client-install/v2.0/tasks/t02_base_install.yml
@@ -230,6 +230,11 @@
     - item.should_install
     - not (result.rc|d(0)) # Make sure that the loop exits if any package installation fails.
 
+- name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> {{ nbu_playbook_type | capitalize }} the NetBackup client software ('Client - Debian')"
+  ansible.builtin.include_tasks: "t03_native_package_install_debian.yml"
+  when:
+    - ansible_os_family == 'Debian'
+    
 - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Set fact for install-phase"
   set_fact: 
     install_phase: "POST"
@@ -282,7 +287,7 @@
     success_msg: "PASS: All NetBackup RPM's for proposed version are installed successfully."
     fail_msg: "ERROR: [{{ nbu_failed_rpms }}] Selected RPM's failed to install successfully."
     quiet: true
-
+ 
 # Remove the temporary file from /tmp folder after all the rpms are installed successfully.
 - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Remove the nbap_partial_install_detected file from {{ os_path_openv_tmp }} "
   ansible.builtin.file:
@@ -330,5 +335,6 @@
 - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Remove NetBackup EEB RPM Markers"
   ansible.builtin.shell: ( rpm -qa | grep '^VRTSnbeeb\|^VRTSnb-vts2' | while read line; do rpm -e $line; done)
   changed_when: false
+  failed_when: false
 
 # EOF

--- a/roles/netbackup/posix/nbu-client-install/v2.0/tasks/t03_native_package_install_debian.yml
+++ b/roles/netbackup/posix/nbu-client-install/v2.0/tasks/t03_native_package_install_debian.yml
@@ -1,0 +1,86 @@
+# $Copyright: Copyright (c) 2025 Cohesity, Inc. All rights reserved $
+
+- name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Debian installation steps"
+  block: #always
+    # Create directory for /usr/openv/tmp if it does not exist
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Create base directory for NetBackup temporary files"
+      ansible.builtin.file:
+        path: "{{ os_path_openv_tmp }}/netbackup_debian_packages"
+        state: directory
+        mode: '0755'
+
+    # Tasks for Debian systems
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Download NetBackup Debian package"
+      ansible.builtin.get_url:
+        url: "{{ nbu_artifactory_repo_base_url }}{{ artifactory_repo }}{{ nbu_path_repo_base_pkg }}/{{ netbackup_debian_package }}{{package_extension}}"
+        dest: "{{ os_path_openv_tmp }}"
+        mode: '0644'
+      
+    # Extract NetBackup Debian package
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Extract NetBackup Debian package"
+      ansible.builtin.unarchive:
+        src: "{{ os_path_openv_tmp }}/{{ netbackup_debian_package }}{{package_extension}}"
+        dest: "{{ os_path_openv_tmp }}/netbackup_debian_packages/"
+        remote_src: yes
+
+    # Upload NetBackup Inputs file ("Client - Linux")
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Upload NetBackup Install/Upgrade Inputs file ('Client - Debian')"
+      ansible.builtin.template:
+        src: "NBInstallUserInput-client-debian.j2"
+        dest: "{{ os_path_openv_tmp }}/netbackup_debian_packages/NBInstallUserInput-client-debian.conf"
+        mode: '0755'
+
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Verify install script exists and is executable"
+      ansible.builtin.stat:
+        path: "{{ os_path_openv_tmp }}/netbackup_debian_packages/install"
+      register: install_script_check
+
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Fail if install script is missing or not executable"
+      ansible.builtin.fail:
+        msg: |
+          {{ os_path_openv_tmp }}/netbackup_debian_packages/install: No such file or directory. Please check if the package was uploaded correctly and verify the naming convention in the README file.
+      when: not install_script_check.stat.exists
+
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Run NetBackup install script using NBInstallAnswer.conf and stdin inputs"
+      ansible.builtin.shell: "./install < {{ os_path_openv_tmp }}/netbackup_debian_packages/NBInstallUserInput-client-debian.conf"
+      args: 
+        chdir: "{{ os_path_openv_tmp }}/netbackup_debian_packages"
+      register: netbackup_install_result_register  
+      no_log: true
+      failed_when: false
+
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Find most recent install trace file"
+      ansible.builtin.find:
+        paths: "{{ os_path_openv_tmp }}"
+        patterns: "install_trace.*"
+        age_stamp: mtime
+      register: trace_files_register
+
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Get latest trace file"
+      ansible.builtin.set_fact:
+        latest_trace_file: "{{ (trace_files_register.files | sort(attribute='mtime') | last).path | basename }}"
+      when: trace_files_register.files | length > 0
+
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Handle successful installation"
+      ansible.builtin.debug:
+        msg: "All NetBackup RPM's for proposed version are installed successfully."
+      when: netbackup_install_result_register.rc == 0
+
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Handle installation failures"
+      ansible.builtin.fail:
+        msg: |
+          NetBackup installation failed with exit code {{ netbackup_install_result_register.rc }}. Check the install trace file at {{ os_path_openv_tmp }}/{{ latest_trace_file | default('unresolved') }} for detailed error information.
+      when: netbackup_install_result_register.rc != 0
+
+  always:
+    # After Netbackup Debian Install/Upgrade, remove all user input directories and files from target host
+    - name: "NBU-CLIENT-{{ nbu_playbook_type|upper }} -> Clean up Debian package from target host"
+      ansible.builtin.file:
+        path: "{{ item_to_delete }}"
+        state: absent 
+      loop:
+        - "{{ os_path_openv_tmp }}/{{netbackup_debian_package }}{{package_extension}}"
+        - "{{ os_path_openv_tmp }}/netbackup_debian_packages/"
+      loop_control:
+        loop_var: item_to_delete
+

--- a/roles/netbackup/posix/nbu-client-install/v2.0/templates/NBInstallUserInput-client-debian.j2
+++ b/roles/netbackup/posix/nbu-client-install/v2.0/templates/NBInstallUserInput-client-debian.j2
@@ -1,0 +1,8 @@
+{# Do you wish to continue #}
+y
+{# Do you want to install the NetBackup client software for this client #}
+y
+{# Enter the name of the NetBackup primary server #}
+{{ nbu_primary_server_ans }}
+{# Would you like to use "<client name>" as the configured name of the NetBackup client. #}
+y

--- a/roles/netbackup/posix/nbu-install-eeb/v2.0/tasks/t01_base_patch_eeb.yml
+++ b/roles/netbackup/posix/nbu-install-eeb/v2.0/tasks/t01_base_patch_eeb.yml
@@ -200,5 +200,7 @@
       when:
        - ( eeb_marker_check_register.rc == 0 )
        - ( eeb_task_type == "install" )
-  when: include_eeb_rpm_marker
+  when:
+  - ansible_os_family != 'Debian'
+  - include_eeb_rpm_marker
 #EOF

--- a/roles/netbackup/posix/nbu-install-verification/tasks/main.yml
+++ b/roles/netbackup/posix/nbu-install-verification/tasks/main.yml
@@ -4,7 +4,7 @@
 #### nbu-install-verification -> tasks -> main.yml ####
 #####################################################################
 
-# Determine the NetBackup server installed software version 
+# Determine the NetBackup server installed software version
 - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Determine the NetBackup {{ nbu_role|capitalize }} installed software version"
   block:
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify whether NetBackup {{ nbu_role }} software is currently installed"
@@ -16,7 +16,7 @@
     # Verify what version of the NetBackup client software is currently installed.
     # Returned version is used to determine whether the NetBackup client sofware requires upgrading.
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify what version of the NetBackup {{ nbu_role }} software is currently installed"
-      ansible.builtin.shell:  "{{ version_check_cmd | replace('ITEM_PACKAGE_NAME', nbu_rpm_vrtsnbcfg) }}"
+      ansible.builtin.shell: "{{ version_check_cmd | replace('ITEM_PACKAGE_NAME', nbu_rpm_vrtsnbcfg) }}"
       changed_when: false
       register: nbu_rpm_version_register
       when:
@@ -28,17 +28,22 @@
 - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Detect if NetBackup {{ nbu_role | capitalize }} ({{ nbu_rpm_version_register.stdout | default(nbu_version) }}) is currently installed"
   ansible.builtin.set_fact:
     nbu_rpm_version: "{{ nbu_rpm_version_register.stdout | default(nbu_version) }}"
-
+   
 # Include tasks to verify the NetBackup installation/upgrade status
 - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Include tasks for NetBackup {{ nbu_playbook_type }} status verification"
   ansible.builtin.include_tasks: t01_{{ nbu_playbook_type }}_status.yml
   when:      
+      - ansible_os_family != "Debian"
       - item.shared is not defined
       - (item.platforms is not defined or nbu_current_os_arch in item.platforms)
       - (item.role is not defined or nbu_role in item.role)
       - (item.optional is not defined or (item.name == 'VRTSnbjre' and nbu_role == 'primary'))
   with_items:
     - "{{ nbu_pkgs_ordered_list[nbu_version] }}"
+
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Include tasks for NetBackup {{ nbu_playbook_type }} status verification"
+  ansible.builtin.include_tasks: t01_debian_status.yml
+  when: ansible_os_family == "Debian"
 
 # Set facts about the NetBackup Client
 # Does not run if NetBackup Client software is not installed
@@ -85,6 +90,5 @@
   ansible.builtin.debug:
     msg: "Installed NetBackup {{ nbu_role }} version ({{ nbu_rpm_version }}) is up-to-date"
   when: ( nbu_install_status == "none" )
-
 
 # EOF

--- a/roles/netbackup/posix/nbu-install-verification/tasks/t01_debian_status.yml
+++ b/roles/netbackup/posix/nbu-install-verification/tasks/t01_debian_status.yml
@@ -1,0 +1,117 @@
+# $Copyright: Copyright (c) 2025 Veritas Technologies LLC. All rights reserved $
+
+#############################################################################
+#### nbu-debian-install-upgrade-status -> tasks -> t01_debian_status.yml ####
+#############################################################################
+
+# These tasks will verify the workflow is being executed on a current NetBackup version
+# and will determine whether the NetBackup software requires installation.
+
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify whether NetBackup {{ nbu_role }} software is currently installed"
+  ansible.builtin.shell: "{{ pkg_status_check_cmd }}"
+  changed_when: false
+  register: nbu_rpm_check_register
+  failed_when: false 
+
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify NetBackup version for Debian-based systems"
+  ansible.builtin.shell: "{{ version_check_cmd }}"
+  changed_when: false
+  failed_when: false
+  register: nbu_version_deb_register
+  when:
+    - ( nbu_rpm_check_register.rc == 0 )
+      
+- block:
+    - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Set NetBackup Version from version.txt"
+      ansible.builtin.set_fact:
+        nbu_current_installed_version: "{{ nbu_version_deb_register.stdout }}" 
+
+    - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Formatting NetBackup Version into x.x.x.x format"
+      ansible.builtin.set_fact:
+        nbu_current_installed_version: "{{ nbu_current_installed_version + '.' + '0' * (1 - (nbu_current_installed_version | regex_replace('.', '') | length) ) }}"
+      when: nbu_current_installed_version | regex_findall('\.') | length < 3
+      loop: "{{ range(3) | list }}"
+  when:
+    - ( nbu_rpm_check_register.rc == 0 )
+    - ( nbu_version_deb_register.rc == 0 )
+    - ( nbu_version_deb_register.stdout != "" )   
+
+# Verify new install NetBackup
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify whether to install NetBackup {{ nbu_role }} - Set fact to 'install'"
+  ansible.builtin.set_fact:
+    nbu_install_counter: "{{ nbu_install_counter | default(0) | int + 1 }}"
+  when:
+    - nbu_playbook_type == "install"
+    - ( nbu_rpm_check_register.rc != 0 )
+
+# Verify if the installed NetBackup version is out-of-date and requires upgrading
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify whether installed NetBackup {{ nbu_role }} version ({{ nbu_current_installed_version }}) is out-of-date - Set fact to 'upgrade'"
+  ansible.builtin.set_fact:
+    nbu_upgrade_counter: "{{ nbu_upgrade_counter | default(0) | int + 1 }}"
+  when:
+    - nbu_playbook_type == "upgrade"
+    - nbu_current_installed_version is defined
+    - nbu_current_installed_version is version_compare(nbu_version, '<') 
+  
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Setting the eventual install status"
+  ansible.builtin.set_fact:
+    nbu_install_status: none
+  when:
+    - nbu_playbook_type == "install"
+    - ( nbu_install_counter |int == 0 )
+    - install_phase == "PRE"
+
+# Verify if the installed NetBackup version matches the proposed version
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify whether installed NetBackup {{ nbu_role }} version matches proposed version"
+  ansible.builtin.set_fact:
+    nbu_install_status: none
+  when:
+    - nbu_playbook_type == "upgrade"
+    - nbu_current_installed_version is defined
+    - nbu_current_installed_version == nbu_version
+
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Setting the eventual install status"
+  ansible.builtin.set_fact:
+    nbu_install_status: install
+    nbu_failed_rpms: "NetBackup Clients"  
+  when:  
+    - nbu_install_counter is defined
+    - ( nbu_install_counter |int == 1 )
+
+# Set the upgrade status if the version is out-of-date
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Setting the eventual upgrade status"
+  ansible.builtin.set_fact:
+    nbu_install_status: upgrade
+    nbu_failed_rpms: "NetBackup Clients"
+  when:
+    - nbu_upgrade_counter is defined
+    - nbu_upgrade_counter | int > 0
+    - install_phase == "PRE"     
+ 
+# Fail if an incompatible version is installed
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Fail if an incompatible version is installed"
+  ansible.builtin.fail:
+    msg: "This machine has an incompatible version: {{ nbu_current_installed_version }} of NetBackup installed. Exiting immediately."
+  when:
+    - nbu_playbook_type == "install"
+    - nbu_current_installed_version is defined
+    - ( nbu_current_installed_version is version_compare(nbu_version, '<')) or ( nbu_current_installed_version is version_compare(nbu_version, '>') )
+    - install_phase == "PRE"
+
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify whether NetBackup {{ nbu_role }} is currently installed"
+  fail:
+    msg:  "This machine doesn't have NetBackup {{ nbu_role | capitalize }} installed, hence cannot be upgraded, therefore exit immediately."
+  when:
+    - nbu_playbook_type == "upgrade"
+    - ( nbu_rpm_check_register.rc == 1 )
+    - install_phase == "PRE"
+
+# Verify if the installed NetBackup version is higher than the proposed version. 
+- name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Verify if the installed NetBackup {{ nbu_role }} version is compatible for upgrade with ({{ rpm_proposed_version }}) "
+  fail:
+    msg: "Installed NetBackup version:{{ nbu_current_installed_version }} is higher than proposed version, therefore exit immediately."
+  when: 
+    - nbu_playbook_type == "upgrade"
+    - nbu_current_installed_version is version_compare(nbu_version, '>')
+
+# EOF

--- a/roles/netbackup/posix/nbu-install-verification/tasks/t01_upgrade_status.yml
+++ b/roles/netbackup/posix/nbu-install-verification/tasks/t01_upgrade_status.yml
@@ -55,7 +55,7 @@
     - ( nbu_upgrade_counter |int == 0 )
     - install_phase == "PRE"
 
-- name: Ansible::Log.info
+- name: "NBU-{{ nbu_role|upper }}-UPGRADE -> Verify whether NetBackup {{ nbu_role }} is currently installed"
   fail:
     msg:  "This machine doesn't have NetBackup {{ nbu_role | capitalize }} installed, hence cannot be upgraded, therefore exit immediately."
   when:

--- a/roles/netbackup/posix/nbu-remove/v2.0/tasks/t03_base_remove.yml
+++ b/roles/netbackup/posix/nbu-remove/v2.0/tasks/t03_base_remove.yml
@@ -215,6 +215,27 @@
       ansible.builtin.shell: "{{ delete_nbu_links_cmd | replace('ITEM_LINK_NAME', item ) }}"
       with_items: "{{ nbu_directory_list_to_be_removed }}"
 
+    - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Remove NetBackup xinetd configurations (bpcd, vnetd, vopied)"
+      ansible.builtin.file:
+        path: "/etc/xinetd.d/{{ item }}"
+        state: absent
+      loop:
+        - bpcd
+        - vnetd
+        - vopied
+      failed_when: false
+
+    - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Remove NetBackup init script from /etc/init.d/"
+      ansible.builtin.file:
+        path: '{{ item }}'
+        state: absent
+      failed_when: false
+      with_items:
+        - /etc/rc0.d/K01netbackup
+        - /etc/rc1.d/K01netbackup
+        - /etc/rc2.d/S95netbackup
+        - /etc/init.d/netbackup
+
     - name: "NBU-{{ nbu_role|upper }}-{{ nbu_playbook_type|upper }} -> Delete NetBackup files"
       ansible.builtin.shell: "{{ delete_nbu_files_cmd | replace('ITEM_FILE_NAME', item ) }}"
       with_items: "{{ nbu_directory_list_to_be_removed }}"

--- a/roles/netbackup/posix/tasks/initialize_clis.yml
+++ b/roles/netbackup/posix/tasks/initialize_clis.yml
@@ -13,6 +13,7 @@
     delete_nbu_files_cmd: "undefined"
     delete_nbu_directories_cmd: "undefined"
     eeb_netbackup_version_cmd: "EEB_PATH/EEB_NAME -eeb_ver | awk -F'NetBackup_' '/NetBackup_/ {print $2}' | awk -F. '{printf \"%d.%d.%d.%d\\n\", $1, ($2?$2:0), ($3?$3:0), ($4?$4:0)}'"
+    nbcheck_package_name: "VRTSnbpck"
 
 - name: "NBU-INITIALIZE-{{ nbu_playbook_type|upper }} -> Initializing {{ ansible_system }} platform specifics settings"
   ansible.builtin.set_fact:
@@ -27,6 +28,16 @@
     delete_nbu_files_cmd: "find 'ITEM_FILE_NAME' -type f -print0 | xargs -0 rm -f"
     delete_nbu_directories_cmd: "find 'ITEM_DIR_NAME' -type d -print0 | xargs -0 rm -rf"
   when: ansible_system == 'Linux'
+
+- name: "NBU-INITIALIZE-{{ nbu_playbook_type|upper }} -> Initializing {{ ansible_system }} platform specifics settings"
+  ansible.builtin.set_fact:
+    package_extension: ".tar.gz"
+    version_check_cmd: "grep -oE '[0-9]+\\.[0-9]+(\\.[0-9]+)*(\\.[0-9]+)*' {{ os_path_nbu_install }}/netbackup/bin/version | tail -1 | awk -F. '{printf \"%d.%d.%d.%d\\n\", $1, ($2?$2:0), ($3?$3:0), ($4?$4:0)}'"
+    pkg_status_check_cmd: "ls {{ os_path_nbu_install }}/netbackup/bin/version"
+    nbcheck_package_name: "{{ netbackup_debian_package }}"
+    nbcheck_package_extraction_cmd: "tar -xzf {{ os_path_openv_tmp }}/{{ netbackup_debian_package }}.tar.gz $(tar -tzf {{ os_path_openv_tmp }}/{{ netbackup_debian_package }}.tar.gz | grep 'NBClients/anb/Clients/usr/openv/netbackup/client/Linux/Debian.*/nbcheck$' | head -1) --strip-components=9"
+    nb_check_path: "{{ os_path_openv_tmp }}/nbcheck"
+  when: ansible_os_family == 'Debian'
 
 - name: "NBU-INITIALIZE-{{ nbu_playbook_type|upper }} -> Initializing {{ ansible_system }} platform specifics settings"
   ansible.builtin.set_fact:
@@ -58,6 +69,15 @@
     delete_nbu_directories_cmd: "rm -rf 'ITEM_DIR_NAME' 2>/dev/null || true"
     eeb_pkg_installcmd: "echo all | pkgadd -a {{ os_path_openv_tmp }}/netbackup_sunos_packages/.pkg_defaults -d ITEM_EEB_MARKER_PACKAGE.pkg"
   when: ansible_system == 'SunOS'
+
+- name: "NBU-INITIALIZE-{{ nbu_playbook_type|upper }} -> Initializing {{ ansible_system }} platform specifics settings"
+  ansible.builtin.set_fact:
+    installed_packages_list_query_cmd: "[ -f /usr/openv/netbackup/bin/version ]"
+    version_check_cmd: "awk '{print $2}' {{ os_path_nbu_install }}/netbackup/bin/version | grep -oE '^[0-9]+(\\.[0-9]+)*'"
+    delete_nbu_links_cmd: "find 'ITEM_LINK_NAME' -type l -exec rm -f {} + 2>/dev/null || true"
+    delete_nbu_files_cmd: "find 'ITEM_FILE_NAME' -type f -exec rm -f {} + 2>/dev/null || true"
+    delete_nbu_directories_cmd: "rm -rf 'ITEM_DIR_NAME' 2>/dev/null || true"
+  when: ansible_os_family == 'Debian'
 
 - name: "NBU-INITIALIZE-{{ nbu_playbook_type|upper }} -> Initialize DirectIO installation decision"
   block:

--- a/roles/netbackup/win32nt/defaults/main.yml
+++ b/roles/netbackup/win32nt/defaults/main.yml
@@ -21,6 +21,7 @@ setup_vcredist_params_default: "/STOP_NB_BEFORE_VCREDIST:'YES' /VCREDIST_ATTEMPT
 # Windows DVD image name for each NetBackup release.
 nbu_pkgs_ordered_list:
   client:
+    11.1.0.2: 'NetBackup_11.1.0.2_Win'
     11.1.0.0: 'NetBackup_11.1_Win'
     11.0.0.1: 'NetBackup_11.0.0.1_Win'
     11.0.0.0: 'NetBackup_11.0_Win'

--- a/vars/linux.yml
+++ b/vars/linux.yml
@@ -2,7 +2,7 @@
  
 # These vars are mostly customer-centric and would get updated.
 # Desired NetBackup Client Version to use in the format [x.x.x.x]
-# Supported versions: ['11.1.0.0','11.0.0.1', '11.0.0.0', '10.5.0.1', '10.5.0.0' ]
+# Supported versions: ['11.1.0.2', '11.1.0.0', '11.0.0.1', '11.0.0.0', '10.5.0.1', '10.5.0.0' ]
 nbu_version: x.x.x.x
 
 Comment: >
@@ -58,7 +58,7 @@ nbu_directory_list_to_be_removed:                         # Custom list of direc
 - "{{ os_path_nbu_install_default }}"
 
 # FTO (Feature Toggle Options)                            # Valid options given can be true|false|yes|no|y|n|1|0
-include_eeb_rpm_marker: false                             # If set to true, playbook wil create/delete extra RPM marker
+include_eeb_rpm_marker: false                             # If set to true, playbook will create/delete extra RPM marker. This option is not applicable for Debian
 nb_include_java_jre_install: false                        # For include java jre packages
 include_directio_install: 'MATCH'                         # DirectIO package installation behavior:
                                                            #   INCLUDE - Include the NetBackup DirectIO

--- a/vars/win32nt.yml
+++ b/vars/win32nt.yml
@@ -2,7 +2,7 @@
 
 # These vars are mostly customer-centric and would get updated.
 # Desired NetBackup Client Version to use in the format [x.x.x.x]
-# Supported versions: ['11.1.0.0', '11.0.0.1', '11.0.0.0','10.5.0.1', '10.5.0.0' ]
+# Supported versions: ['11.1.0.2', '11.1.0.0', '11.0.0.1', '11.0.0.0','10.5.0.1', '10.5.0.0' ]
 nbu_version: x.x.x.x
 
 Comment: >


### PR DESCRIPTION
1.  Add NetBackup 11.1.0.2 support
2.  Extended compatibility to include NetBackup 11.1.0.2 across all supported platforms.
3. Enable fresh install, upgrade, and remove operations for NetBackup clients on Debian-based and Ubuntu platforms 
4. Add automated certificate deployment for Debian/Ubuntu clients